### PR TITLE
Filter user data and integrate @Drama_Cloud

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,8 @@ jobs:
 
       - name: Prepare Docker Build Files
         run: |
-          cp dev/Aeon .
-          chmod +x Aeon
+          cp dev/DramaCloud .
+          chmod +x DramaCloud
 
       - name: Build and Push
         uses: docker/build-push-action@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,7 +125,7 @@ jobs:
                   'HEROKU_API_KEY': getattr(config, 'HEROKU_API_KEY', ''),
                   'HEROKU_EMAIL': getattr(config, 'HEROKU_EMAIL', ''),
                   'HEROKU_TEAM_NAME': getattr(config, 'HEROKU_TEAM_NAME', ''),
-                  'UPSTREAM_REPO': getattr(config, 'UPSTREAM_REPO', 'https://github.com/AeonOrg/Aeon-MLTB'),
+                  'UPSTREAM_REPO': getattr(config, 'UPSTREAM_REPO', 'https://github.com/DramaCloud/DramaCloud-Bot'),
                   'UPSTREAM_BRANCH': getattr(config, 'UPSTREAM_BRANCH', 'extended'),
                   'AUTO_REDEPLOY': str(getattr(config, 'AUTO_REDEPLOY', False)).lower(),
                   'REDEPLOY_INTERVAL_DAYS': str(getattr(config, 'REDEPLOY_INTERVAL_DAYS', 7)),
@@ -268,5 +268,5 @@ jobs:
           HD_BOT_TOKEN: ${{ github.event_name == 'workflow_dispatch' && (env.CONFIG_BOT_TOKEN || inputs.BOT_TOKEN || secrets.BOT_TOKEN) || (env.CONFIG_BOT_TOKEN || secrets.BOT_TOKEN) }}
           HD_HEROKU_APP_NAME: ${{ github.event_name == 'workflow_dispatch' && (env.CONFIG_HEROKU_APP_NAME || inputs.HEROKU_APP_NAME || secrets.HEROKU_APP_NAME) || (env.CONFIG_HEROKU_APP_NAME || secrets.HEROKU_APP_NAME) }}
           HD_HEROKU_API_KEY: ${{ github.event_name == 'workflow_dispatch' && (env.CONFIG_HEROKU_API_KEY || inputs.HEROKU_API_KEY || secrets.HEROKU_API_KEY) || (env.CONFIG_HEROKU_API_KEY || secrets.HEROKU_API_KEY) }}
-          HD_UPSTREAM_REPO: ${{ env.CONFIG_UPSTREAM_REPO || secrets.UPSTREAM_REPO || 'https://github.com/AeonOrg/Aeon-MLTB' }}
+          HD_UPSTREAM_REPO: ${{ env.CONFIG_UPSTREAM_REPO || secrets.UPSTREAM_REPO || 'https://github.com/DramaCloud/DramaCloud-Bot' }}
           HD_UPSTREAM_BRANCH: ${{ env.CONFIG_UPSTREAM_BRANCH || secrets.UPSTREAM_BRANCH || 'extended' }}

--- a/.github/workflows/notification.yml
+++ b/.github/workflows/notification.yml
@@ -17,7 +17,7 @@ jobs:
           AUTHOR_URL: https://github.com/${{ github.actor }}
           COMMITS_JSON: ${{ toJson(github.event.commits) }}
         run: |
-          if [[ "$REPO" != "AeonOrg/Aeon-MLTB" ]]; then
+          if [[ "$REPO" != "DramaCloud/DramaCloud-Bot" ]]; then
             echo "Repository is not the original. Skipping Telegram notification."
             exit 0
           fi

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
-![](https://github.com/5hojib/5hojib/raw/main/images/Aeon-MLTB.gif)
+# Drama Cloud Bot
 
----
-
-# Aeon-MLTB Bot
-
-Aeon-MLTB is a streamlined and feature-rich bot designed for efficient deployment and enhanced functionality.
+Drama Cloud Bot is a streamlined and feature-rich bot designed for efficient deployment and enhanced functionality.
 
 ---
 
@@ -18,11 +14,11 @@ Aeon-MLTB is a streamlined and feature-rich bot designed for efficient deploymen
 
 ## Read these
 
-[Deployment](https://github.com/AeonOrg/Aeon-MLTB/blob/extended/docs/DEPLOYMENT.md)
-[Configuration](https://github.com/AeonOrg/Aeon-MLTB/blob/extended/docs/CONFIGURATIONS.md)
-[Commands](https://github.com/AeonOrg/Aeon-MLTB/blob/extended/docs/COMMANDS.md)
-[Features](https://github.com/AeonOrg/Aeon-MLTB/blob/extended/docs/FEATURES.md)
-[Extras](https://github.com/AeonOrg/Aeon-MLTB/blob/extended/docs/EXTRAS.md)
+[Deployment](docs/DEPLOYMENT.md)
+[Configuration](docs/CONFIGURATIONS.md)
+[Commands](docs/COMMANDS.md)
+[Features](docs/FEATURES.md)
+[Extras](docs/EXTRAS.md)
 
 ---
 
@@ -36,7 +32,7 @@ We welcome contributions! Whether it's bug fixes, feature enhancements, or gener
 
 ## Support
 
-For issues, join here https://t.me/AeonDiscussion.
+For issues, join here https://t.me/DramaCloud.
 
 ---
 
@@ -49,4 +45,4 @@ This project is licensed under the MIT License. Refer to the [LICENSE](LICENSE) 
 ## Acknowledgements
 
 - Special thanks to the original developers of the [Mirror-Leech-Telegram-Bot](https://github.com/anasty17/mirror-leech-telegram-bot).
-- Gratitude to contributors from various repositories whose features have been integrated into Aeon.
+- Gratitude to contributors from various repositories whose features have been integrated into Drama Cloud Bot.

--- a/bot/core/config_manager.py
+++ b/bot/core/config_manager.py
@@ -1342,7 +1342,7 @@ class Config:
 
     # Branding Settings
     CREDIT: str = (
-        "Powered by @aimmirror"  # Credit text shown in status messages and RSS feeds
+        "Powered by @Drama_Cloud"  # Credit text shown in status messages and RSS feeds
     )
     OWNER_THUMB: str = "https://graph.org/file/80b7fb095063a18f9e232.jpg"  # Default thumbnail URL for owner
 

--- a/bot/core/config_manager.py
+++ b/bot/core/config_manager.py
@@ -632,7 +632,7 @@ class Config:
         ""  # Default tags for uploaded videos, separated by comma
     )
     YOUTUBE_UPLOAD_DEFAULT_DESCRIPTION: str = (
-        "Uploaded by AIM"  # Default description for uploaded videos
+        "Uploaded by Drama Cloud Bot"  # Default description for uploaded videos
     )
     YOUTUBE_UPLOAD_DEFAULT_TITLE: str = (
         ""  # Default title template (empty = use filename)

--- a/bot/helper/common.py
+++ b/bot/helper/common.py
@@ -4369,7 +4369,7 @@ class TaskConfig:
                         )
                         self.split_size = None
 
-            # Old Aeon-MLTB logic: Only store custom split size if explicitly set by user
+            # Old Drama Cloud Bot logic: Only store custom split size if explicitly set by user
             # The actual splitting decision will be made in proceed_split based on max_split_size
             if not self.split_size:
                 # User settings have priority for custom split sizes

--- a/bot/helper/ext_utils/config_utils.py
+++ b/bot/helper/ext_utils/config_utils.py
@@ -1172,7 +1172,7 @@ async def reset_youtube_configs(database):
         "YOUTUBE_UPLOAD_DEFAULT_PRIVACY": "unlisted",
         "YOUTUBE_UPLOAD_DEFAULT_CATEGORY": "22",
         "YOUTUBE_UPLOAD_DEFAULT_TAGS": "",
-        "YOUTUBE_UPLOAD_DEFAULT_DESCRIPTION": "Uploaded by AIM",
+        "YOUTUBE_UPLOAD_DEFAULT_DESCRIPTION": "Uploaded by Drama Cloud Bot",
     }
 
     # Update global configurations

--- a/bot/helper/ext_utils/files_utils.py
+++ b/bot/helper/ext_utils/files_utils.py
@@ -366,7 +366,7 @@ async def split_file(f_path, split_size, listener):
         LOGGER.error(f"Split input file does not exist: {f_path}")
         return False
 
-    # Get file size for logging (Old Aeon-MLTB logic - simple and clean)
+    # Get file size for logging (Old Drama Cloud Bot logic - simple and clean)
     try:
         file_size = await aiopath.getsize(f_path)
         file_size_gb = file_size / (1024 * 1024 * 1024)
@@ -381,7 +381,7 @@ async def split_file(f_path, split_size, listener):
         LOGGER.error(f"Error calculating file size: {e}")
         # Continue with the split operation anyway
 
-    # Create the command (Old Aeon-MLTB logic - trust the split_size passed from proceed_split)
+    # Create the command (Old Drama Cloud Bot logic - trust the split_size passed from proceed_split)
     # The split_size has already been validated in proceed_split and get_user_split_size
     split_size_bytes = int(split_size)
 
@@ -483,7 +483,7 @@ async def split_file(f_path, split_size, listener):
                 )
             return False
 
-        # Simple validation - just log the split files created (Old Aeon-MLTB approach)
+        # Simple validation - just log the split files created (Old Drama Cloud Bot approach)
         LOGGER.info(f"Successfully split {f_path} into {len(split_files)} parts")
 
         # Log the first few split file names for debugging

--- a/bot/helper/ext_utils/help_messages.py
+++ b/bot/helper/ext_utils/help_messages.py
@@ -2450,7 +2450,7 @@ tool_other_features = """<b>📦 Other Tools & Features</b>
 <b>💡 Examples:</b>
 <code>/tool https://github.com/torvalds/linux</code>
 <code>/tool https://github.com/microsoft/vscode</code>
-<code>/tool git@github.com:AeonOrg/Aeon-MLTB.git</code>
+<code>/tool git@github.com/DramaCloud/DramaCloud-Bot.git</code>
 
 <b>📋 Download Details:</b>
 • Downloads the latest main/master branch

--- a/bot/helper/ext_utils/media_utils.py
+++ b/bot/helper/ext_utils/media_utils.py
@@ -709,7 +709,7 @@ async def get_media_type(file_path):
 
 
 async def take_ss(video_file, ss_nb) -> bool:
-    """Take screenshots from video using simple approach like old Aeon"""
+    """Take screenshots from video using simple approach like old Drama Cloud Bot"""
     duration = (await get_media_info(video_file))[0]
     if duration != 0:
         dirpath, name = video_file.rsplit("/", 1)
@@ -4003,7 +4003,7 @@ async def remove_tracks(
 
 
 async def get_video_thumbnail(video_file, duration):
-    """Extract a thumbnail from a video file using simple approach like old Aeon"""
+    """Extract a thumbnail from a video file using simple approach like old Drama Cloud Bot"""
     output_dir = f"{DOWNLOAD_DIR}thumbnails"
     await makedirs(output_dir, exist_ok=True)
     output = ospath.join(output_dir, f"{time()}.jpg")

--- a/bot/helper/ext_utils/mega_utils.py
+++ b/bot/helper/ext_utils/mega_utils.py
@@ -23,7 +23,7 @@ def configure_mega_import():
 
 def _configure_mega_library_path():
     """Configure library path for MEGA SDK imports"""
-    # Primary installation paths (based on Aeon script)
+    # Primary installation paths (based on Drama Cloud Bot script)
     mega_paths = [
         "/usr/local/lib/python3.13/dist-packages/mega",
         "/usr/lib/python3/dist-packages/mega",

--- a/bot/helper/mirror_leech_utils/telegram_uploader.py
+++ b/bot/helper/mirror_leech_utils/telegram_uploader.py
@@ -141,13 +141,13 @@ class TelegramUploader:
         self._transmission_stopped = False
 
     def _apply_prefix_suffix_simple(self, filename):
-        """Apply prefix and suffix to filename - Old Aeon-MLTB style"""
+        """Apply prefix and suffix to filename - Old Drama Cloud Bot style"""
         if not self._lprefix and not self._lsuffix:
             return filename
 
         result = filename
 
-        # Apply prefix (like old Aeon-MLTB)
+        # Apply prefix (like old Drama Cloud Bot)
         if self._lprefix:
             clean_prefix = re_sub("<.*?>", "", self._lprefix)
             if clean_prefix and not result.startswith(clean_prefix):
@@ -156,7 +156,7 @@ class TelegramUploader:
                     clean_prefix = f"{clean_prefix} "
                 result = f"{clean_prefix}{result}"
 
-        # Apply suffix (like old Aeon-MLTB)
+        # Apply suffix (like old Drama Cloud Bot)
         if self._lsuffix:
             clean_suffix = re_sub("<.*?>", "", self._lsuffix)
             if clean_suffix:
@@ -190,7 +190,7 @@ class TelegramUploader:
 
     def _build_caption_with_html_prefix_suffix(self, core_content):
         """
-        Build caption with HTML prefix and suffix around core content - Old Aeon-MLTB style.
+        Build caption with HTML prefix and suffix around core content - Old Drama Cloud Bot style.
         HTML tags are preserved for Telegram rendering.
         """
         caption = core_content
@@ -254,7 +254,7 @@ class TelegramUploader:
             else False
         )
 
-        # Use the same logic as old Aeon-MLTB for consistency
+        # Use the same logic as old Drama Cloud Bot for consistency
         self._lprefix = self._listener.user_dict.get("LEECH_FILENAME_PREFIX") or (
             Config.LEECH_FILENAME_PREFIX
             if "LEECH_FILENAME_PREFIX" not in self._listener.user_dict
@@ -292,7 +292,7 @@ class TelegramUploader:
 
     def _build_caption_with_prefix_suffix(self, core_content):
         """
-        Build caption with HTML prefix and suffix around core content - Old Aeon-MLTB style.
+        Build caption with HTML prefix and suffix around core content - Old Drama Cloud Bot style.
         Uses the new HTML-aware method for consistent behavior.
         """
         return self._build_caption_with_html_prefix_suffix(core_content)
@@ -491,7 +491,7 @@ class TelegramUploader:
                 # Set final filename for file operations
                 final_filename = working_filename
 
-            # Step 3: Apply prefix and suffix to filename - Old Aeon-MLTB style
+            # Step 3: Apply prefix and suffix to filename - Old Drama Cloud Bot style
             original_filename = final_filename
             final_filename = self._apply_prefix_suffix_simple(final_filename)
 
@@ -501,7 +501,7 @@ class TelegramUploader:
                     f"Applied prefix/suffix: {original_filename} -> {final_filename}"
                 )
 
-            # Add HTML prefix/suffix to caption for default captions - Old Aeon-MLTB style
+            # Add HTML prefix/suffix to caption for default captions - Old Drama Cloud Bot style
             if cap_mono and not has_leech_caption:
                 cap_mono = self._build_caption_with_html_prefix_suffix(cap_mono)
 
@@ -1604,7 +1604,7 @@ class TelegramUploader:
                 destinations.append(self._user_id)
         else:
             # No specific destination was specified
-            # Follow the standard destination logic based on old Aeon-MLTB requirements
+            # Follow the standard destination logic based on old Drama Cloud Bot requirements
 
             # Check if user has set their own dump
             user_dump = self._user_dump
@@ -1914,7 +1914,7 @@ class TelegramUploader:
                 destinations.append(self._user_id)
         else:
             # No specific destination was specified
-            # Follow the standard destination logic based on old Aeon-MLTB requirements
+            # Follow the standard destination logic based on old Drama Cloud Bot requirements
 
             # Check if user has set their own dump
             user_dump = self._user_dump

--- a/bot/modules/bot_settings.py
+++ b/bot/modules/bot_settings.py
@@ -274,7 +274,7 @@ DEFAULT_VALUES = {
     "YOUTUBE_UPLOAD_DEFAULT_PRIVACY": "unlisted",
     "YOUTUBE_UPLOAD_DEFAULT_CATEGORY": "22",
     "YOUTUBE_UPLOAD_DEFAULT_TAGS": "",
-    "YOUTUBE_UPLOAD_DEFAULT_DESCRIPTION": "Uploaded by AIM",
+    "YOUTUBE_UPLOAD_DEFAULT_DESCRIPTION": "Uploaded by Drama Cloud Bot",
     # Watermark Settings
     "WATERMARK_ENABLED": False,
     "WATERMARK_KEY": "",
@@ -3738,7 +3738,7 @@ These are advanced settings that should only be modified if you understand their
         category = Config.YOUTUBE_UPLOAD_DEFAULT_CATEGORY or "22 (Default)"
         tags = Config.YOUTUBE_UPLOAD_DEFAULT_TAGS or "None (Default)"
         description = (
-            Config.YOUTUBE_UPLOAD_DEFAULT_DESCRIPTION or "Uploaded by AIM (Default)"
+            Config.YOUTUBE_UPLOAD_DEFAULT_DESCRIPTION or "Uploaded by Drama Cloud Bot (Default)"
         )
 
         msg = f"""<b>📺 YouTube General Settings</b> | State: {state}
@@ -13115,7 +13115,7 @@ async def edit_bot_settings(client, query):
         Config.YOUTUBE_UPLOAD_DEFAULT_PRIVACY = "unlisted"
         Config.YOUTUBE_UPLOAD_DEFAULT_CATEGORY = "22"
         Config.YOUTUBE_UPLOAD_DEFAULT_TAGS = ""
-        Config.YOUTUBE_UPLOAD_DEFAULT_DESCRIPTION = "Uploaded by AIM"
+        Config.YOUTUBE_UPLOAD_DEFAULT_DESCRIPTION = "Uploaded by Drama Cloud Bot"
 
         # Update the database
         await database.update_config(
@@ -13123,7 +13123,7 @@ async def edit_bot_settings(client, query):
                 "YOUTUBE_UPLOAD_DEFAULT_PRIVACY": "unlisted",
                 "YOUTUBE_UPLOAD_DEFAULT_CATEGORY": "22",
                 "YOUTUBE_UPLOAD_DEFAULT_TAGS": "",
-                "YOUTUBE_UPLOAD_DEFAULT_DESCRIPTION": "Uploaded by AIM",
+                "YOUTUBE_UPLOAD_DEFAULT_DESCRIPTION": "Uploaded by Drama Cloud Bot",
             }
         )
         # Update the UI - go back to YouTube main menu

--- a/bot/modules/bot_settings.py
+++ b/bot/modules/bot_settings.py
@@ -292,7 +292,7 @@ DEFAULT_VALUES = {
     # Audio Watermark Settings
     "AUDIO_WATERMARK_VOLUME": 0.0,
     # Branding Settings
-    "CREDIT": "Powered by @aimmirror",
+    "CREDIT": "Powered by @Drama_Cloud",
     "OWNER_THUMB": "https://graph.org/file/80b7fb095063a18f9e232.jpg",
     "AUDIO_WATERMARK_INTERVAL": 0,
     # Subtitle Watermark Settings

--- a/config_sample.py
+++ b/config_sample.py
@@ -23,11 +23,11 @@ AUTO_REDEPLOY = False  # Enable/disable automatic redeployment on schedule
 REDEPLOY_INTERVAL_DAYS = 7  # Auto redeploy interval in days (1, 3, 7, 14, or 30)
 
 # Update
-UPSTREAM_REPO = "https://github.com/AeonOrg/Aeon-MLTB"  # Repository URL for updates
-UPSTREAM_BRANCH = "extended"  # Branch to use for updates
+UPSTREAM_REPO = "https://github.com/DramaCloud/DramaCloud-Bot"  # Repository URL for updates
+UPSTREAM_BRANCH = "main"  # Branch to use for updates
 
 # Branding Settings
-CREDIT = "Powered by @aimmirror"  # Credit text shown in status messages and RSS feeds (default: "Powered by @aimmirror")
+CREDIT = "Powered by @Drama_Cloud"  # Credit text shown in status messages and RSS feeds (default: "Powered by @Drama_Cloud")
 OWNER_THUMB = "https://graph.org/file/80b7fb095063a18f9e232.jpg"  # Default thumbnail URL for owner (accepts Telegram file links)
 
 # OPTIONAL CONFIG
@@ -814,7 +814,7 @@ YOUTUBE_UPLOAD_DEFAULT_TAGS = (
     ""  # Default tags for uploaded videos, separated by comma
 )
 YOUTUBE_UPLOAD_DEFAULT_DESCRIPTION = (
-    "Uploaded by Aeon"  # Default description for uploaded videos
+    "Uploaded by Drama Cloud Bot"  # Default description for uploaded videos
 )
 YOUTUBE_UPLOAD_DEFAULT_TITLE = ""  # Default title template (empty = use filename)
 # Title template supports variables: {filename}, {date}, {time}, {size}

--- a/docs/CONFIGURATIONS.md
+++ b/docs/CONFIGURATIONS.md
@@ -508,7 +508,7 @@
 | `YOUTUBE_UPLOAD_DEFAULT_PRIVACY` | `str` | Default privacy setting: `public`, `unlisted`, `private`. Default: `unlisted`. |
 | `YOUTUBE_UPLOAD_DEFAULT_CATEGORY` | `str` | Default category ID (22 = People & Blogs). Default: `22`. |
 | `YOUTUBE_UPLOAD_DEFAULT_TAGS` | `str` | Default tags for uploaded videos, separated by comma. |
-| `YOUTUBE_UPLOAD_DEFAULT_DESCRIPTION` | `str` | Default description for uploaded videos. Default: `Uploaded by AIM`. |
+| `YOUTUBE_UPLOAD_DEFAULT_DESCRIPTION` | `str` | Default description for uploaded videos. Default: `Uploaded by Drama Cloud Bot`. |
 | `YOUTUBE_UPLOAD_DEFAULT_TITLE` | `str` | Default title template (empty = use filename). |
 
 ### Advanced YouTube API Settings

--- a/docs/CONFIGURATIONS.md
+++ b/docs/CONFIGURATIONS.md
@@ -1142,7 +1142,7 @@
 | `CORRECT_CMD_SUFFIX`   | `str`  | Comma-separated list of allowed command suffixes. |
 | `WRONG_CMD_WARNINGS_ENABLED` | `bool` | Enable/disable warnings for wrong command suffixes. Default: `False`. |
 
-## 21. Extra fields from Aeon
+## 21. Extra fields from Drama Cloud Bot
 
 | Variable               | Type   | Description |
 |------------------------|--------|-------------|
@@ -1161,7 +1161,7 @@
 | `LOGIN_PASS`           | `str`  | Password for web login authentication. |
 | `AD_KEYWORDS`          | `str`  | Custom keywords/phrases for ad detection, separated by comma. |
 | `AD_BROADCASTER_ENABLED` | `bool` | Enable/disable automatic ad broadcasting from FSUB channels to users. Default: `False`. |
-| `CREDIT`               | `str`  | Credit text shown in status messages and RSS feeds. Default: `Powered by @aimmirror`. |
+| `CREDIT`               | `str`  | Credit text shown in status messages and RSS feeds. Default: `Powered by @Drama_Cloud`. |
 | `OWNER_THUMB`          | `str`  | Default thumbnail URL for owner. Default: `https://graph.org/file/80b7fb095063a18f9e232.jpg`. |
 | `PIL_MEMORY_LIMIT`     | `int`  | PIL memory limit in MB. Default: `2048`. |
 | `MEDIA_SEARCH_CHATS`   | `list` | List of chat IDs for media search functionality. |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,13 +1,13 @@
 ## Deployment Instructions through Google Colab (Heroku)
 
-Follow these steps to deploy Aeon-MLTB to Heroku using Google Colab:
+Follow these steps to deploy Drama Cloud Bot to Heroku using Google Colab:
 
 ### 1. Open the Colab Notebook
 - Click on this link to open the deployment notebook: [Deploy to Heroku via Colab](https://colab.research.google.com/github/AeonOrg/Aeon-MLTB/blob/deploy_extended/Deploy_to_Heroku.ipynb)
 - Make sure you're signed in to your Google account.
 
 ### 2. Fork and Star the Repository
-- Before proceeding with the deployment, fork the [Aeon-MLTB repository](https://github.com/AeonOrg/Aeon-MLTB).
+- Before proceeding with the deployment, fork the [Drama Cloud Bot repository](https://github.com/DramaCloud/DramaCloud-Bot).
 - Give the repository a star to show your support.
 
 ### 3. Prepare Required Information
@@ -36,7 +36,7 @@ Gather the following information before running the notebook:
 
 ## Deployment Instructions through Github Workflow (Heroku)
 
-Follow these steps to deploy Aeon-MLTB to Heroku:
+Follow these steps to deploy Drama Cloud Bot to Heroku:
 
 ### 1. Fork and Star the Repository
 - Click the **Fork** button at the top-right corner of this repository.
@@ -72,7 +72,7 @@ Follow these steps to deploy Aeon-MLTB to Heroku:
 
 ## Deployment Instructions (VPS)
 
-Follow these steps to deploy Aeon to VPS:
+Follow these steps to deploy Drama Cloud Bot to VPS:
 
 ### 1. Star the Repository
 - Give the repository a star to show your support.
@@ -81,7 +81,7 @@ Follow these steps to deploy Aeon to VPS:
 - Clone the repository to your VPS.
 
 ```
-git clone https://github.com/AeonOrg/Aeon-MLTB.git && cd Aeon-MLTB && git checkout extended
+git clone https://github.com/DramaCloud/DramaCloud-Bot.git && cd DramaCloud-Bot && git checkout main
 ```
 
 ### 3. Install Requirements
@@ -160,13 +160,13 @@ sudo docker compose logs --follow
 - Build Docker image:
 
 ```
-sudo docker build . -t aeon-mltb
+sudo docker build . -t drama-cloud-bot
 ```
 
 - Run the image:
 
 ```
-sudo docker run --network host aeon-mltb
+sudo docker run --network host drama-cloud-bot
 ```
 
 - To stop the running image:
@@ -204,7 +204,7 @@ sudo ./open_ports.sh
 ## Heroku CLI Deploy Guide (Windows, Linux, Android)
 
 ### Overview
-This guide provides step-by-step instructions for deploying Aeon-MLTB to Heroku using the command line interface (CLI) across different platforms. This method deploys the **extended** branch directly to Heroku.
+This guide provides step-by-step instructions for deploying Drama Cloud Bot to Heroku using the command line interface (CLI) across different platforms. This method deploys the **main** branch directly to Heroku.
 
 ### Prerequisites
 - Git installed on your system
@@ -238,13 +238,13 @@ pkg update -y && pkg install git -y
 #### 1. Fork and Clone Repository
 
 1. **Fork the Repository**
-   - Go to [https://github.com/AeonOrg/Aeon-MLTB](https://github.com/AeonOrg/Aeon-MLTB)
+   - Go to [https://github.com/DramaCloud/DramaCloud-Bot](https://github.com/DramaCloud/DramaCloud-Bot)
    - Click the **Fork** button to create your own copy
    - Star the repository to show support
 
-2. **Clone Your Fork and Switch to deploy_extended Branch**
+2. **Clone Your Fork and Switch to main Branch**
 ```bash
-git clone https://github.com/YOUR-GITHUB-USERNAME/Aeon-MLTB.git && cd Aeon-MLTB && git checkout deploy_extended
+git clone https://github.com/YOUR-GITHUB-USERNAME/DramaCloud-Bot.git && cd DramaCloud-Bot && git checkout main
 ```
 Replace `YOUR-GITHUB-USERNAME` with your actual GitHub username.
 
@@ -342,8 +342,8 @@ This command pushes your local `deploy` branch (which contains the extended bran
 
 ### Video Guides
 
-- **Android Guide**: [Telegram Link](https://t.me/AeonDiscussion/80629)
-- **Linux Guide**: [Telegram Link](https://t.me/AeonDiscussion/80729)
+- **Android Guide**: [Telegram Link](https://t.me/DramaCloud/80629)
+- **Linux Guide**: [Telegram Link](https://t.me/DramaCloud/80729)
 
 ### Updating Your Deployment
 
@@ -365,7 +365,7 @@ If any major update comes then redeploy is recommended following the same method
 
 ---
 
-## Aeon-MLTB Docker Image Build Guide
+## Drama Cloud Bot Docker Image Build Guide
 
 ### Usage
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -3,7 +3,7 @@
 Follow these steps to deploy Drama Cloud Bot to Heroku using Google Colab:
 
 ### 1. Open the Colab Notebook
-- Click on this link to open the deployment notebook: [Deploy to Heroku via Colab](https://colab.research.google.com/github/AeonOrg/Aeon-MLTB/blob/deploy_extended/Deploy_to_Heroku.ipynb)
+- Click on this link to open the deployment notebook: [Deploy to Heroku via Colab](https://colab.research.google.com/github/DramaCloud/DramaCloud-Bot/blob/main/Deploy_to_Heroku.ipynb)
 - Make sure you're signed in to your Google account.
 
 ### 2. Fork and Star the Repository

--- a/update.py
+++ b/update.py
@@ -109,7 +109,7 @@ if DATABASE_URL:
 UPSTREAM_REPO = (
     config_file.get("UPSTREAM_REPO", "")
     or os.getenv("UPSTREAM_REPO", "")
-    or "https://github.com/AeonOrg/Aeon-MLTB"
+    or "https://github.com/DramaCloud/DramaCloud-Bot"
 )
 
 UPSTREAM_BRANCH = (

--- a/web/wserver.py
+++ b/web/wserver.py
@@ -797,8 +797,8 @@ async def qbittorrent_proxy(path: str = "", request: Request = None):
 async def homepage():
     return (
         "<h1>See multi-purpose telegram bot at "
-        "<a href='https://github.com/AeonOrg/Aeon-MLTB/tree/extended'>@GitHub</a> "
-        "By <a href='https://github.com/AeonOrg'>AeonOrg</a></h1>"
+        "<a href='https://github.com/DramaCloud/DramaCloud-Bot'>@GitHub</a> "
+"By <a href='https://github.com/DramaCloud'>DramaCloud</a></h1>"
     )
 
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove "aimmirror" and "aeon" branding and data, replacing them with "@Drama_Cloud" to personalize the bot.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR updates various user-facing elements, documentation, and configuration files to reflect the new branding, ensuring that only the user's specified data and branding are visible. Key changes include:
- Updating `CREDIT` settings.
- Changing GitHub repository references.
- Renaming "Aeon-MLTB" to "Drama Cloud Bot" in documentation and comments.
- Adjusting YouTube upload descriptions and help messages.
- Updating Docker image names and deployment instructions.

---
<a href="https://cursor.com/background-agent?bcId=bc-8a4048c2-7800-4972-a1db-d0177365f329">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8a4048c2-7800-4972-a1db-d0177365f329">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>